### PR TITLE
Improve link hover color contrast for WCAG AA compliance

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -166,7 +166,7 @@ a {
   font-weight: 600;
   text-decoration: none;
   &:hover {
-    color: red;
+    color: #c00;
   }
   &:focus {
     outline: 0;
@@ -269,8 +269,8 @@ img.art {
   padding: 10px 20px;
   margin-top: 30px;
   &:hover {
-    color: red;
-    border-color: red;
+    color: #c00;
+    border-color: #c00;
   }
 }
 


### PR DESCRIPTION
## Summary
- Change link hover color from red (#FF0000, 3.9:1 ratio) to #c00 (5.9:1 ratio)
- Applies to general links and check-it-out buttons

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)