### PR TITLE
Restore keyboard focus styles

### DIFF
--- a/_includes/themes/minimalber/default.html
+++ b/_includes/themes/minimalber/default.html
@@ -47,7 +47,7 @@
     <div class="wrapper">
       {% include navbar.html %}
 
-      <div class="container-fluid content">
+      <div class="container-fluid content" id="main-content">
         {{ content }}
       </div>
     </div>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -169,7 +169,8 @@ a {
     color: red;
   }
   &:focus {
-    outline: 0;
+    outline: 2px solid #005fcc;
+    outline-offset: 2px;
   }
 }
 

--- a/_sass/_madoka.scss
+++ b/_sass/_madoka.scss
@@ -32,7 +32,8 @@ $secondaryColor: #219FFF;
 }
 
 .input__field:focus {
-	outline: none;
+	outline: 2px solid #005fcc;
+	outline-offset: 2px;
 }
 
 .input__label {


### PR DESCRIPTION
## Summary
- Replace removed focus outlines with visible 2px blue focus rings on links and input fields
- Add `id="main-content"` landmark to content container for accessibility

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)